### PR TITLE
Update README to fix incorrect --batch-size parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,8 @@ TF_CPP_MIN_LOG_LEVEL=2 \
 python train_agent.py \
     --game_class="games.connect_four_game.Connect4Game" \
     --agent_class="policies.resnet_policy.ResnetPolicyValueNet" \
-    --batch-size=4096 \
+    --selfplay-batch-size=4096 \
+    --training-batch-size=4096 \
     --num_simulations_per_move=32 \
     --num_self_plays_per_iteration=102400 \
     --learning-rate=1e-2 \


### PR DESCRIPTION
It looks like the training parameter for batch size was originally named `batch_size`, but eventually it was changed to `selfplay_batch_size` and `training_batch_size`. The README example for Connect Four was never updated. It happens to be the first example that anyone sees.

Unfortunately `fire` doesn't error when a misnamed argument is specified, so I ended up running the default batch size on my laptop instead of batch size 1 as I intended, and didn't notice until training was complete.